### PR TITLE
Remove pipelineGroup from schema

### DIFF
--- a/dip.schema.json
+++ b/dip.schema.json
@@ -55,9 +55,6 @@
         "atzDataConfig":{
             "type": "object",
             "properties": {
-              "pipelineGroup": {
-                  "type": "string"
-              },
               "maskId": {
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
As per the discussions at the end of last week, instead of using a pipelineGroup field within the JSON schemas we will use folders to organize the pipeline groupings for Terraform