### PR TITLE
Add useTimestampForQuery to Source object

### DIFF
--- a/dip.schema.json
+++ b/dip.schema.json
@@ -124,7 +124,7 @@
                 "delta"
               ]
             },
-            "useTimestampForQuery": {
+            "ignoreQueryTimestamp": {
               "type": "boolean"              
             }
           },

--- a/dip.schema.json
+++ b/dip.schema.json
@@ -123,6 +123,9 @@
                 "full",
                 "delta"
               ]
+            },
+            "useTimestampForQuery": {
+              "type": "boolean"              
             }
           },
           "required": [


### PR DESCRIPTION
- New boolean field `useTimestampForQuery` will serve as a flag to provide the option on bypassing the read/write to Firestore within the Snaplogic CloudDataWarehouse pipelines. 
- Although similar to the field `loadType=delta/full`, this new field will provide additional flexibility to handle possible future corner cases (eg. Are we sure that if  `loadType=full` that we will _never_ want to write to Firestore?)