### PR TITLE
Add regex for title field validation

### DIFF
--- a/dip.schema.json
+++ b/dip.schema.json
@@ -167,7 +167,8 @@
       "additionalProperties": false
     },
     "title": {
-      "type": "string"
+      "type": "string",
+      "pattern": "(([a-zA-Z0-9_])\\.([a-zA-Z0-9_]))"
     },
     "description": {
       "type": "string"

--- a/dip.schema.json
+++ b/dip.schema.json
@@ -168,7 +168,7 @@
     },
     "title": {
       "type": "string",
-      "pattern": "(([a-zA-Z0-9_])\\.([a-zA-Z0-9_]))"
+      "pattern": "([a-zA-Z0-9]+)_(sbx|dev|qa|prd).([a-zA-Z0-9]+)"
     },
     "description": {
       "type": "string"


### PR DESCRIPTION
Title regex must now be `<datasource>`_`<environment>`.`<table|topic>`

where `<environment>` is one of: `sbx`, `dev`, `qa`, `prd`