### PR TITLE
Add w2p as a valid source type

### DIFF
--- a/dip.schema.json
+++ b/dip.schema.json
@@ -142,6 +142,17 @@
             },
             "type": {
               "type": "string"
+            },
+            "labels": {
+              "type": "object",
+              "properties": {
+                "application-name": {
+                  "type": "string"
+                },
+                "technical-owner": {
+                  "type": "string"
+                }
+              }              
             }
           },
           "required": [

--- a/dip.schema.json
+++ b/dip.schema.json
@@ -142,17 +142,6 @@
             },
             "type": {
               "type": "string"
-            },
-            "labels": {
-              "type": "object",
-              "properties": {
-                "application-name": {
-                  "type": "string"
-                },
-                "technical-owner": {
-                  "type": "string"
-                }
-              }
             }
           },
           "required": [

--- a/dip.schema.json
+++ b/dip.schema.json
@@ -110,7 +110,8 @@
               "type": "string",
               "enum": [
                 "gcs",
-                "pubsub"
+                "pubsub",
+                "w2p"
               ]
             },
             "frequency": {


### PR DESCRIPTION
To support automated creation of W2P resources we are adding an additional source type `w2p`, that is distinct from normal `pubsub` resources which will now only be used for pre-existing Pub/Sub topics/subscriptions.