### PR TITLE
Limit the number of characters in a description

### DIFF
--- a/dip.schema.json
+++ b/dip.schema.json
@@ -172,7 +172,8 @@
       "pattern": "([a-zA-Z0-9]+)_(sbx|dev|qa|prd).([a-zA-Z0-9]+)"
     },
     "description": {
-      "type": "string"
+      "type": "string",
+      "pattern": ".{0,1024}"
     },
     "default": true,
     "readOnly": {


### PR DESCRIPTION
BigQuery limits the number of characters allowed in a column description to 1024. Enforce this limit here to prevent failures downstream.