### PR TITLE
Fix regex for title

### DIFF
--- a/dip.schema.json
+++ b/dip.schema.json
@@ -169,7 +169,7 @@
     },
     "title": {
       "type": "string",
-      "pattern": "([a-zA-Z0-9]+)_(sbx|dev|qa|prd).([a-zA-Z0-9]+)"
+      "pattern": "([a-zA-Z0-9]+)_(sbx|dev|qa|prd)\.([a-zA-Z0-9]+)"
     },
     "description": {
       "type": "string",


### PR DESCRIPTION
Period is not being matched explicitly but is being treated as a wildcard character, this should force the correct behaviour.