### PR TITLE
DPE-50 properties as optional/null

### DIFF
--- a/dip.schema.json
+++ b/dip.schema.json
@@ -162,7 +162,8 @@
         }
       },
       "required": [
-        "source"
+        "source",
+        "target"
       ],
       "additionalProperties": false
     },

--- a/dip.schema.json
+++ b/dip.schema.json
@@ -162,8 +162,7 @@
         }
       },
       "required": [
-        "source",
-        "target"
+        "source"
       ],
       "additionalProperties": false
     },
@@ -261,7 +260,7 @@
       "default": {}
     },
     "properties": {
-      "type": "object",
+      "type": ["object", "null"],
       "additionalProperties": {
         "$ref": "#"
       },


### PR DESCRIPTION
Properties can also be `null` in order to support w2p type only, so bigquery tables/fields will not be provisioned