### PR TITLE
Add one of the pre-approved labels

### DIFF
--- a/dip.schema.json
+++ b/dip.schema.json
@@ -142,6 +142,9 @@
             "labels": {
               "type": "object",
               "properties": {
+                  "application-name": {
+                  "type": "string"
+                },
               },
               "additionalProperties": true
             }


### PR DESCRIPTION
JSON schema won't support an empty properties object (even with additionalProperties enabled).